### PR TITLE
Don't modify nodeid when plugin is disabled

### DIFF
--- a/pytest_pspec/plugin.py
+++ b/pytest_pspec/plugin.py
@@ -31,6 +31,9 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
+    if not config.option.pspec:
+        return
+    
     for item in items:
         node = item.obj
         parent = item.parent.obj

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -24,6 +24,17 @@ class TestReport(object):
         expected = '\033[92m ✓ a feature is working\033[0m'
         assert expected in result.stdout.str()
 
+    def test_should_not_modify_nodeid_when_disabled_test(self, testdir):
+        testdir.makepyfile("""
+            def test_a_feature_is_working():
+                assert True
+        """)
+
+        result = testdir.runpytest('-v')
+
+        expected = 'test_should_not_modify_nodeid_when_disabled_test.py::test_a_feature_is_working'
+        assert expected in result.stdout.str()
+
     def test_should_print_a_red_failing_test(self, testdir):
         testdir.makepyfile("""
             def test_a_failed_test_of_a_feature():


### PR DESCRIPTION
Right now pspec plugin modifies internal nodeids of tests even when the plugin is disabled. It can break the behavior of other systems/apps that rely on nodeid being valid. For example, https://github.com/kondratyev-nv/vscode-python-test-adapter/issues/220. 

This PR is a quick fix to disable nodeid modification when the plugin is disabled.

Overall, I would consider removing nodeid modification altogether. For example, collect all nodeid -> spec name mappings to some dictionary and use it during reporting. It's just an idea from the top of my mind, not sure if it would work, though.