### PR TITLE
Parametrization support

### DIFF
--- a/pytest_pspec/plugin.py
+++ b/pytest_pspec/plugin.py
@@ -36,6 +36,10 @@ def pytest_collection_modifyitems(config, items):
         parent = item.parent.obj
         node_parts = item.nodeid.split('::')
         node_str = node.__doc__ or node_parts[-1]
+
+        if hasattr(item, "callspec"):
+            node_str = node_str.format(**item.callspec.params)
+
         mode_str = node_parts[0]
         klas_str = ''
         node_parts_length = len(node_parts)


### PR DESCRIPTION
Fixes #1.

I'm handling exceptions as pytest internal errors. This seems sensible to me. I didn't see any other tests for specific exceptions to mimic.